### PR TITLE
Add some checks to the plugin

### DIFF
--- a/sample/src/Main.fs
+++ b/sample/src/Main.fs
@@ -30,7 +30,7 @@ defineComponent "inner-component" (Haunted.Component(inner_component, {| observe
 /// but in some conditons fable will emit an arrow function so this will not be attached
 /// and your dicpatch might fail
 [<VirtualComponent>]
-let virtual_component (props: {| sample: string |}) =
+let virtual_component (name: string) (age: int) =
     let state, setState = Haunted.useState "I'm so virtual!"
 
     html
@@ -38,7 +38,7 @@ let virtual_component (props: {| sample: string |}) =
         <div>
             <p>A virtual component can keep its own state</p>
             <input value={state} @keyup={fun (ev: Event) -> ev.target.Value |> setState}>
-            <p>External message: {props.sample}</p>
+            <p>External message: {name} is {age} year(s) old</p>
             <p>Internal message: {state}</p>
         </div>"""
 
@@ -67,7 +67,7 @@ let private app () =
         <h1>Hello, World!</h1>
         <!--You can observe attributes or even properties thanks to lit's templating engine -->
         <inner-component sample="lol" .property="{10}"></inner-component>
-        {virtual_component {| sample = "Hi from above!" |}}
+        {virtual_component "John" 45}
         {not_a_component ()}
         <p>Counter: {state}</p>
         <button @click="{fun _ -> dispatch Increment}">Increment</button>

--- a/src/Fable.HauntedPlugins/Plugins.fs
+++ b/src/Fable.HauntedPlugins/Plugins.fs
@@ -34,18 +34,41 @@ module internal Util =
             member _.IsEnumerator = infoOr (fun i -> i.IsEnumerator) false
             member _.IsMangled = infoOr (fun i -> i.IsMangled) false
 
+    let isEntity (fullname: string) (fableType: Fable.Type) =
+        match fableType with
+        | Fable.Type.DeclaredType (entity, _genericArgs) -> entity.FullName = fullname
+        | _ -> false
+
+    let isRecord (compiler: Fable.PluginHelper) (fableType: Fable.Type) =
+        match fableType with
+        | Fable.Type.AnonymousRecordType _ -> true
+        | Fable.Type.DeclaredType (entity, _genericArgs) -> compiler.GetEntity(entity).IsFSharpRecord
+        | _ -> false        
+
 /// Generates a virtual component out of a render function.
 /// See: https://hauntedhooks.netlify.app/docs/guides/virtual/
 type VirtualComponentAttribute() =
     inherit Fable.MemberDeclarationPluginAttribute()
     override _.FableMinimumVersion = "3.0"
-    override _.TransformCall(_,_,expr) = expr
-    override _.Transform(_compiler, _file, decl) =
-        let t = Fable.Any // TODO: Type
-        let virtualFn = Util.makeImport "virtual" "haunted"
-        let fn = Fable.Delegate(decl.Args, decl.Body, None)
-        let body = Fable.CurriedApply(virtualFn, [fn], t, None)
-        { decl with
-            Info = Util.MemberInfo(decl.Info, isValue=true)
-            Args = []
-            Body = body }
+
+    override _.TransformCall(_compiler, _memb, expr) = expr
+
+    override _.Transform(compiler, _file, decl) =
+        if decl.Info.IsValue || decl.Info.IsGetter || decl.Info.IsSetter then
+            // Invalid attribute usage
+            let errorMessage = sprintf "Expecting a function declation for %s when using [<VirtualComponent>]" decl.Name
+            compiler.LogWarning(errorMessage, ?range=decl.Body.Range)
+            decl
+        else if not (Util.isEntity "Lit.TemplateResult" decl.Body.Type) then
+            // output of a function component must be Lit.TemplateResult
+            let errorMessage = sprintf "Expected function %s to return Lit.TemplateResult when using [<VirtualComponent>]. Instead it returns %A" decl.Name decl.Body.Type
+            compiler.LogWarning(errorMessage, ?range=decl.Body.Range)
+            decl
+        else
+            let virtualFn = Util.makeImport "virtual" "haunted"
+            let fn = Fable.Delegate(decl.Args, decl.Body, None)
+            let body = Fable.CurriedApply(virtualFn, [fn], fn.Type, None)
+            { decl with
+                Info = Util.MemberInfo(decl.Info, isValue=true)
+                Args = []
+                Body = body }


### PR DESCRIPTION
I was carefully adding the argument conversion to the plugin and got it working... just to realize Haunted virtual components [accept multiple arguments out-of-the-box](https://github.com/matthewp/haunted/blob/b1ec3f31591d097e3c9ad1e5df3b16a878ddc37e/src/virtual.ts#L7-L9). I was just assuming they behaved like React components 😅 

So at the end this PR just adds some checks to make sure the attribute is being applied correctly. They are useful but it's not urgent to release a new version.

(BTW, I've also released a new version of the highlight extension to fix some issues in the sample.)